### PR TITLE
chore: fix link to vaadin directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Published on Vaadin Directory](https://img.shields.io/badge/Vaadin%20Directory-published-00b4f0.svg)](https://vaadin.com/directory/component/image-comparison-slider-addon)
-[![Stars on vaadin.com/directory](https://img.shields.io/vaadin-directory/star/image-comparison-slider-addon.svg)](https://vaadin.com/directory/component/image-comparison-slider-addon)
+[![Published on Vaadin Directory](https://img.shields.io/badge/Vaadin%20Directory-published-00b4f0.svg)](https://vaadin.com/directory/component/image-comparison-slider-add-on)
+[![Stars on vaadin.com/directory](https://img.shields.io/vaadin-directory/star/image-comparison-slider-add-on.svg)](https://vaadin.com/directory/component/image-comparison-slider-add-on)
 [![Build Status](https://jenkins.flowingcode.com/job/ImageComparisonSlider-addon/badge/icon)](https://jenkins.flowingcode.com/job/image-comparison-slider-addon)
 
 # Image Comparison Slider Add-on
@@ -16,7 +16,7 @@ Vaadin Flow Component for displaying two images side by side with a slider for c
 
 ## Download release
 
-[Available in Vaadin Directory](https://vaadin.com/directory/component/image-comparison-slider-addon)
+[Available in Vaadin Directory](https://vaadin.com/directory/component/image-comparison-slider-add-on)
 
 ## Building and running demo
 


### PR DESCRIPTION
The addon was published as `image-comparison-slider-add-on` but the readme had links to `image-comparison-slider-addon`