### PR TITLE
fix(demo): not set full height

### DIFF
--- a/src/test/java/com/flowingcode/vaadin/addons/ics/ICSDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/ics/ICSDemo.java
@@ -18,7 +18,7 @@ public class ICSDemo extends Div {
     img2.setWidthFull();
     ImageComparisonSlider ics = new ImageComparisonSlider(img1, img2);
     ics.setValue(70);
-    ics.setSizeFull();
+    ics.setWidthFull();
     ics.setSlideOnHover(true);
     add(ics);
   }


### PR DESCRIPTION
Set `fullWidth` instead of `fullSize`, so that the component height does not cover the blank part of the window below the image, thus fixing an issue with the hover behavior in the demo.